### PR TITLE
Fix issue with bold text getting reset to normal

### DIFF
--- a/shepherd.js/src/components/shepherd-text.svelte
+++ b/shepherd.js/src/components/shepherd-text.svelte
@@ -60,6 +60,10 @@
 
   }
 
+  .shepherd-text b {
+    font-weight: bold;
+  }
+
   .shepherd-text p {
     margin-top: 0;
     margin-bottom: 1rem;


### PR DESCRIPTION
- Explicit font-weight bold for all `<b>` tags under `shepherd-text` class